### PR TITLE
Small tweak for webpack

### DIFF
--- a/src/bloodhound/bloodhound.js
+++ b/src/bloodhound/bloodhound.js
@@ -231,4 +231,4 @@
   }
 
   function ignoreDuplicates() { return false; }
-})(this);
+})(this || window);


### PR DESCRIPTION
This PR addresses an issue with `bloodhound.js`, which assumes the global `this` to be the browser window. When nesting `typeahead.js` in other apps and then using webpack to build, the `this` variable might sometimes be undefined. This change ensures that `this` will always resolve to the browser window if it is otherwise undefined.

Attn: @duien 
